### PR TITLE
Add HF integration

### DIFF
--- a/models_cpc.py
+++ b/models_cpc.py
@@ -15,11 +15,13 @@ import torch.nn as nn
 
 from timm.models.vision_transformer import PatchEmbed, Block
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 import numpy as np
 
 
-class MaskedAutoencoderViT(nn.Module):
+class MaskedAutoencoderViT(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/MCG-NJU/CoMAE.git", pipeline_tag=["image-feature-extraction"]):
 
     def __init__(self, img_size=224, patch_size=16, in_chans=3,
                  embed_dim=1024, depth=24, num_heads=16,

--- a/models_mm_mae.py
+++ b/models_mm_mae.py
@@ -18,9 +18,11 @@ from timm.models.vision_transformer import PatchEmbed, Block
 
 from util.pos_embed import get_2d_sincos_pos_embed
 
+from huggingface_hub import PyTorchModelHubMixin
 
 
-class MaskedAutoencoderViT(nn.Module):
+
+class MaskedAutoencoderViT(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/MCG-NJU/CoMAE.git", pipeline_tag=["image-feature-extraction"]):
     """ Masked Autoencoder with VisionTransformer backbone
     """
 


### PR DESCRIPTION
Hi @yangjiangeyjg,

Thanks for this nice work! I see the checkpoints are currently on Google Drive, this PR aims to make your models discoverable from https://huggingface.co/models?pipeline_tag=image-feature-extraction.

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various CoMAE models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from models_cpc import MaskedAutoencoderViT

# define model
network = MaskedAutoencoderViT(...)

# equip with weights
model.load_state_dict(...)

# push to the hub
model.push_to_hub("MCG-NJU/comae-base")

# reload
model = MaskedAutoencoderViT.from_pretrained("MCG-NJU/comae-base")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. Checkpoints could be pushed to https://huggingface.co/MCG-NJU.

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing a model to the hub :)